### PR TITLE
Fixed synchronous example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ pb.setProcessListener(handler);
 NuProcess process = pb.start();
 
 ByteBuffer buffer = ByteBuffer.wrap("Hello, World!".getBytes());
-buffer.flip();
 process.writeStdin(buffer);
 
 process.waitFor(0, TimeUnit.SECONDS); // when 0 is used for waitFor() the wait is infinite


### PR DESCRIPTION
Removed buffer.flip() from example.
As after ByteBuffer.wrap() it shouldn't be flipped.
